### PR TITLE
Ticket 13: Logging, plots, and result artifacts

### DIFF
--- a/traffic-rl/results_utils.py
+++ b/traffic-rl/results_utils.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+from typing import Iterable
+
+import matplotlib.pyplot as plt
+
+
+def ensure_parent(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+
+def write_csv(path: Path, rows: list[dict], fieldnames: list[str]) -> None:
+    ensure_parent(path)
+    with path.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def save_line_plot(
+    values: Iterable[float],
+    *,
+    xlabel: str,
+    ylabel: str,
+    title: str,
+    path: Path,
+) -> None:
+    ensure_parent(path)
+    plt.figure(figsize=(8, 5))
+    plt.plot(list(values))
+    plt.xlabel(xlabel)
+    plt.ylabel(ylabel)
+    plt.title(title)
+    plt.tight_layout()
+    plt.savefig(path)
+    plt.close()
+
+
+def save_bar_plot(
+    labels: list[str],
+    values: list[float],
+    *,
+    yerr: list[float] | None,
+    ylabel: str,
+    title: str,
+    path: Path,
+) -> None:
+    ensure_parent(path)
+    plt.figure(figsize=(8, 5))
+    x = range(len(labels))
+    plt.bar(x, values, yerr=yerr, capsize=5 if yerr else 0)
+    plt.xticks(list(x), labels)
+    plt.ylabel(ylabel)
+    plt.title(title)
+    plt.tight_layout()
+    plt.savefig(path)
+    plt.close()

--- a/traffic-rl/scripts/run_standard_eval.py
+++ b/traffic-rl/scripts/run_standard_eval.py
@@ -904,6 +904,34 @@ def main() -> None:
         output_prefix=output_prefix,
     )
 
+    # ===== Save comparison plots (Ticket 13) =====
+    from results_utils import save_bar_plot
+
+    plots_dir = PROJECT_ROOT / "results" / "plots"
+    plots_dir.mkdir(parents=True, exist_ok=True)
+
+    rows = [flatten_summary(summary) for summary in summaries]
+    controllers = [row["controller"] for row in rows]
+
+    def make_plot(metric_key, title, filename):
+        values = [row[f"{metric_key}_mean"] for row in rows]
+        errors = [row.get(f"{metric_key}_ci95", 0.0) for row in rows]
+
+        save_bar_plot(
+            controllers,
+            values,
+            yerr=errors,
+            ylabel=title,
+            title=f"{title} by Controller",
+            path=plots_dir / filename,
+        )
+
+    make_plot("mean_waiting_time", "Mean Waiting Time", "eval_wait.png")
+    make_plot("mean_queue_length", "Mean Queue Length", "eval_queue.png")
+    make_plot("throughput", "Throughput", "eval_throughput.png")
+    make_plot("mean_travel_time", "Mean Travel Time", "eval_travel_time.png")
+    make_plot("travel_time_mse", "Travel Time MSE", "eval_mse.png")
+
     print("\nSaved evaluation artifacts:")
     print(f"- {json_path}")
     print(f"- {csv_path}")

--- a/traffic-rl/scripts/train_dqn.py
+++ b/traffic-rl/scripts/train_dqn.py
@@ -284,6 +284,28 @@ def main() -> None:
     print("\n=== Final Comparison ===")
     print(json.dumps(comparison, indent=2))
 
+    # ===== Save per-episode CSV (Ticket 13) =====
+    from results_utils import write_csv
+
+    metrics_dir = PROJECT_ROOT / "results" / "metrics"
+    metrics_dir.mkdir(parents=True, exist_ok=True)
+
+    csv_rows = []
+    for i in range(len(episode_rewards)):
+        csv_rows.append({
+            "episode": i + 1,
+            "reward": float(episode_rewards[i]),
+            "avg_wait": float(episode_avg_waits[i]),
+            "throughput": float(episode_throughputs[i]),
+            "loss": float(episode_losses[i]),
+            "epsilon": float(epsilon),
+        })
+
+    write_csv(
+        metrics_dir / "dqn_training_metrics.csv",
+        csv_rows,
+        ["episode", "reward", "avg_wait", "throughput", "loss", "epsilon"],
+    )
 
 if __name__ == "__main__":
     main()

--- a/traffic-rl/scripts/train_ppo.py
+++ b/traffic-rl/scripts/train_ppo.py
@@ -290,6 +290,27 @@ def main() -> None:
     print("\n=== Final Comparison ===")
     print(json.dumps(comparison, indent=2))
 
+    # ===== Save per-episode CSV (Ticket 13) =====
+    from results_utils import write_csv
+
+    metrics_dir = PROJECT_ROOT / "results" / "metrics"
+    metrics_dir.mkdir(parents=True, exist_ok=True)
+
+    csv_rows = []
+    for i in range(len(episode_rewards)):
+        csv_rows.append({
+            "episode": i + 1,
+            "reward": float(episode_rewards[i]),
+            "avg_wait": float(episode_avg_waits[i]),
+            "throughput": float(episode_throughputs[i]),
+            "loss": float(episode_losses[i]),
+        })
+
+    write_csv(
+        metrics_dir / "ppo_training_metrics.csv",
+        csv_rows,
+        ["episode", "reward", "avg_wait", "throughput", "loss"],
+    )
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Implements Ticket 13: Logging, Plots, and Result Artifacts.

- Added per-episode CSV logging for DQN and PPO training
- Created shared results_utils module for CSV writing and plotting
- Ensured training outputs JSON + CSV + reward/wait/throughput plots
- Added evaluation comparison plots (waiting time, queue length, throughput, travel time, MSE)
- Standardized artifact outputs under results/metrics and results/plots

Evaluation pipeline now produces publishable metrics and plots in a single run.